### PR TITLE
Always attach MPWURLRequest instance to the error object

### DIFF
--- a/Streams.subproj/MPWURLFetchStream.m
+++ b/Streams.subproj/MPWURLFetchStream.m
@@ -178,17 +178,21 @@ CONVENIENCEANDINIT(stream, WithBaseURL:(NSURL*)newBaseURL target:aTarget)
                     NSDictionary *userInfo=
                     @{ @"url": resolvedRequest.URL,
                        @"headers": [(NSHTTPURLResponse*)response allHeaderFields],
-                       @"content": data ? [data stringValue] : @"",
-                       @"request": request,
+                       @"content": data ? [data stringValue] : @""
                        };
                     error = [NSError errorWithDomain:@"network" code:httpStatusCode userInfo:userInfo];
                 }
                 if (data && !error   ){
-//                    NSLog(@"Success: %@",request);
+                    //                    NSLog(@"Success: %@",request);
                     [target writeObject:[self processResponse:request]];
                 } else {
                     NSLog(@"Error: %@",request);
-                    [self reportError:error];
+                    NSMutableDictionary *userInfoWithRequest = [error.userInfo mutableCopy];
+                    userInfoWithRequest[@"request"] = request;
+                    NSError *errorWithRequest = [NSError errorWithDomain:error.domain
+                                                                    code:error.code
+                                                                userInfo:userInfoWithRequest];
+                    [self reportError:errorWithRequest];
                 }
             } @finally {
                 @synchronized (self) {

--- a/Streams.subproj/MPWURLFetchStream.m
+++ b/Streams.subproj/MPWURLFetchStream.m
@@ -183,7 +183,7 @@ CONVENIENCEANDINIT(stream, WithBaseURL:(NSURL*)newBaseURL target:aTarget)
                     error = [NSError errorWithDomain:@"network" code:httpStatusCode userInfo:userInfo];
                 }
                 if (data && !error   ){
-                    //                    NSLog(@"Success: %@",request);
+//                    NSLog(@"Success: %@",request);
                     [target writeObject:[self processResponse:request]];
                 } else {
                     NSLog(@"Error: %@",request);


### PR DESCRIPTION
If a data task fails because of the timeout, then there would be no `response` object, and thus the `httpStatusCode` would be 0. Then the `error` object would not have an attached request. Having an attached request is useful, if not required, to recover from timeout failures.

To reproduce the timeout issue you can enable "100% Loss" profile in the Network Link Conditioner.