### PR TITLE
Specify target thread for MPWURLFetchStream

### DIFF
--- a/Streams.subproj/MPWURLFetchStream.h
+++ b/Streams.subproj/MPWURLFetchStream.h
@@ -23,6 +23,7 @@
 @property (nonatomic, readonly) NSMutableSet *inflight;
 @property (nonatomic, readonly) NSURLSession *downloader;
 @property (assign)  int maxInflight;
+@property (nonatomic, strong) NSThread *targetThread;
 
 +streamWithBaseURL:(NSURL*)newBaseURL target:aTarget session:(NSURLSession*)session;
 -initWithBaseURL:(NSURL*)newBaseURL target:aTarget session:(NSURLSession*)session;

--- a/Streams.subproj/MPWURLFetchStream.m
+++ b/Streams.subproj/MPWURLFetchStream.m
@@ -186,7 +186,14 @@ static NSURLSession *_defaultURLSession=nil;
 
 -(void)reportError:(NSError*)error
 {
-    [self.errorTarget writeObject:error];
+    if (self.targetThread) {
+        [(NSObject<Streaming> *)self.errorTarget performSelector:@selector(writeObject:)
+                                                        onThread:[NSThread currentThread]
+                                                      withObject:error
+                                                   waitUntilDone:NO];
+    } else {
+        [self.errorTarget writeObject:error];
+    }
 }
 
 
@@ -239,7 +246,14 @@ static NSURLSession *_defaultURLSession=nil;
             if (data && !error   ){
                 id processed=[self processResponse:request];
 //                NSLog(@"will write processed: %@ to %@",processed,target);
-                [target writeObject:processed];
+                if (self.targetThread) {
+                    [target performSelector:@selector(writeObject:)
+                                   onThread:self.targetThread
+                                 withObject:processed
+                              waitUntilDone:NO];
+                } else {
+                    [target writeObject:processed];
+                }
             } else {
 //                NSLog(@"Error: %p %@",request,request);
                 NSMutableDictionary *userInfoWithRequest = [error.userInfo mutableCopy];
@@ -342,6 +356,7 @@ static NSURLSession *_defaultURLSession=nil;
     [_defaultMethod release];
     [(NSObject *)_errorTarget release];
     [_baseURL release];
+    [_targetThread release];
     [super dealloc];
 }
 

--- a/Streams.subproj/MPWURLFetchStream.m
+++ b/Streams.subproj/MPWURLFetchStream.m
@@ -188,7 +188,7 @@ static NSURLSession *_defaultURLSession=nil;
 {
     if (self.targetThread) {
         [(NSObject<Streaming> *)self.errorTarget performSelector:@selector(writeObject:)
-                                                        onThread:[NSThread currentThread]
+                                                        onThread:self.targetThread
                                                       withObject:error
                                                    waitUntilDone:NO];
     } else {


### PR DESCRIPTION
`MPWURLFetchStream` would always call its targets (including the error target) on whichever threads the underlaying `NSURLSession` is running on.

This caused thread locking issues in the coalescing while-loop in `-executeRequest:` method: if a request is scheduled on the same thread that `NSURLSession` is running on, this thread would sleep, and so the `NSURLSession` would not be able to complete its request, and so the while-loop will run for a significant time (I've seen up to 25 seconds).

This pull request offers a solution to this problem.