### PR TITLE
added missing source files; ignore allowsCellularAccess in GNUStep

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -103,6 +103,8 @@ libMPWFoundation_OBJC_FILES = \
     Stores.subproj/MPWURLReference.m \
     Stores.subproj/MPWDiskStore.m \
     Stores.subproj/MPWWriteBackCache.m \
+    Stores.subproj/MPWURLSchemeResolver.m \
+    Stores.subproj/MPWURLBinding.m \
     Streams.subproj/MPWByteStream.m \
     Streams.subproj/MPWFlattenStream.m \
     Streams.subproj/MPWArrayFlattenStream.m \
@@ -120,6 +122,12 @@ libMPWFoundation_OBJC_FILES = \
     Streams.subproj/MPWFDStreamSource.m \
     Streams.subproj/MPWStreamSource.m \
     Streams.subproj/MPWQueue.m \
+    Streams.subproj/MPWSkipFilter.m \
+    Streams.subproj/MPWBlockTargetStream.m \
+    Streams.subproj/MPWBytesToLines.m \
+    Streams.subproj/MPWURLCall.m \
+    Streams.subproj/MPWURLStreamingStream.m \
+    Streams.subproj/MPWURLFetchStream.m \
     Plist/MPWBinaryPListWriter.m \
     Plist/MPWNeXTPListWriter.m \
     Plist/MPWBinaryPlist.m \
@@ -127,6 +135,7 @@ libMPWFoundation_OBJC_FILES = \
     JSON/MPWMASONParser.m \
     JSON/MPWObjectBuilder.m \
     JSON/MPWConvertFromJSONStream.m \
+    JSON/MPWJSONWriter.m \
     XML/MPWXmlScanner.m \
     XML/MPWXmlAppleProplistReader.m \
     XML/MPWMAXParser.m \
@@ -160,6 +169,7 @@ libMPWFoundation_OBJC_FILES = \
     Classes/MPWMessageCatcher.m \
     Classes/NSObjectAdditions.m \
     Classes/NSRunLoopAdditions.m \
+    Classes/MPWResource.m \
     Threading.subproj/NSThreadInterThreadMessaging.m \
     Collections.subproj/MPWSmallStringTable.m \
     Collections.subproj/MPWCaseInsensitiveSmallStringTable.m \
@@ -185,7 +195,7 @@ MPWFoundation_SUBPROJECTS = \
 	Comm.subproj		\
 
 
-LIBRARIES_DEPEND_UPON += -lgnustep-base 
+LIBRARIES_DEPEND_UPON += -lgnustep-base -lgnustep-corebase
 
 # LDFLAGS += -L /C/GNUstep/System/Libraries/ix86/mingw32/gnu-gnu-gnu/ 
 
@@ -197,7 +207,7 @@ include $(GNUSTEP_MAKEFILES)/library.make
 -include GNUmakefile.postamble
 
 before-all ::
-	
+
 #	@$(MKDIRS) $(libMPWFoundation_HEADER_FILES_DIR)
 #	cp *.h $(libMPWFoundation_HEADER_FILES_DIR)
 #	cp Collections.subproj/*.h $(libMPWFoundation_HEADER_FILES_DIR)
@@ -213,4 +223,4 @@ test    : libMPWFoundation tester
 	LD_LIBRARY_PATH=/usr/GNUstep/Local/Library/Libraries:/usr/local/lib:${HOME}/Build/obj/ ./GNUstep/testmpwfoundation
 
 tester  :
-	$(CC)  -fobjc-runtime=gnustep-2.1   -I/usr/GNUstep/Local/Library/Headers/ -I.headers -o GNUstep/testmpwfoundation GNUstep/testmpwfoundation.m -L/usr/GNUstep/Local/Library/Libraries/ -L ${HOME}/Build/obj -lMPWFoundation -lgnustep-base -L/usr/local/lib/ -lobjc
+	$(CC)  -fobjc-runtime=gnustep-2.1 -fblocks  -I/usr/GNUstep/Local/Library/Headers/ -I.headers -o GNUstep/testmpwfoundation GNUstep/testmpwfoundation.m -L/usr/GNUstep/Local/Library/Libraries/ -L ${HOME}/Build/obj -lMPWFoundation -lgnustep-base -L/usr/local/lib/ -lobjc

--- a/Streams.subproj/MPWURLFetchStream.m
+++ b/Streams.subproj/MPWURLFetchStream.m
@@ -84,7 +84,10 @@ static NSURLSession *_defaultURLSession=nil;
 -(NSURLSessionConfiguration *)config
 {
     NSURLSessionConfiguration *sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
+#ifndef GNUSTEP
+    // TODO GNUStep has no allowsCellularAccess property defined
     sessionConfiguration.allowsCellularAccess = YES;
+#endif    
     sessionConfiguration.HTTPShouldUsePipelining = YES;
     sessionConfiguration.HTTPShouldSetCookies = YES;
     sessionConfiguration.requestCachePolicy = NSURLRequestReloadIgnoringLocalCacheData;


### PR DESCRIPTION
GNUmakefile should now be in sync with latest refactoring. Added those files to get an error free 'make'. Some are not purely necessary for MPWFoundation, but are referenced in Objective-Smalltalk.

GNUstep NSURLSessionConfiguration does not know the property 'allowsCellularAccess'. I don't like to sprinkle #ifdef's in the source code. If there is a better way ...   